### PR TITLE
Removed Log.d reference to previous classname

### DIFF
--- a/src/com/mopub/nativeads/FlurryStaticNativeAd.java
+++ b/src/com/mopub/nativeads/FlurryStaticNativeAd.java
@@ -62,14 +62,14 @@ public class FlurryStaticNativeAd extends StaticNativeAd {
 
     private synchronized void onFetched(FlurryAdNative adNative) {
         if (adNative != null) {
-            Log.d(kLogTag, "FlurryForwardingNativeAd onFetched: Native Ad fetched successfully!"
+            Log.d(kLogTag, "onFetched: Native Ad fetched successfully!"
                     + adNative.toString());
             setupNativeAd(adNative);
         }
     }
 
     private synchronized void onFetchFailed(FlurryAdNative adNative) {
-        Log.d(kLogTag, "FlurryForwardingNativeAd onFetchFailed: Native ad not available. "
+        Log.d(kLogTag, "onFetchFailed: Native ad not available. "
                 + adNative.toString());
         if (mCustomEventNativeListener != null) {
             mCustomEventNativeListener.onNativeAdFailed(NativeErrorCode.NETWORK_NO_FILL);


### PR DESCRIPTION
Removed old and duplicated references to FlurryForwardingNativeAd as kLogTag already references new name
